### PR TITLE
Move SignalR to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "install-peers",
     "prepublish": "yarn build",
     "build": "node ./node_modules/typescript/bin/tsc --project ./tsconfig.json"
   },
@@ -34,12 +35,14 @@
     "node": ">=6.0.0"
   },
   "engineStrict": true,
-  "dependencies": {
-    "@microsoft/signalr": "^3.1.4"
+  "peerDependencies": {
+    "@microsoft/signalr": "^3.1.4",
+    "redux": "^4.0.5"
   },
   "devDependencies": {
     "@types/node": "^14.0.1",
     "husky": "^4.2.5",
+    "install-peers-cli": "^2.2.0",
     "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1",
     "typescript": "^3.9.2"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,12 +1,16 @@
 import { Callback, CallbackName, WithCallbacksCreator } from './types';
+import { Dispatch } from 'redux';
 
-export const withCallbacks: WithCallbacksCreator = () => {
-  const callbackMap = new Map<CallbackName, Callback>();
+export const withCallbacks: WithCallbacksCreator = <
+  D extends Dispatch = Dispatch,
+  S = any
+>() => {
+  const callbackMap = new Map<CallbackName, Callback<D, S>>();
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const moduleReducer = () => {};
 
-  const add = (name: CallbackName, callback: Callback) => {
+  const add = (name: CallbackName, callback: Callback<D, S>) => {
     callbackMap.set(name, callback);
     return moduleReducer;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export * from './helpers';
 export * from './types';
-export * from '@microsoft/signalr';
 export { default as signalMiddleware } from './signalr-middleware';

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,21 +20,24 @@ export type SignalMiddleware<S = {}, A extends Action = AnyAction> = Middleware<
 >;
 
 export type CallbackName = string;
-export type Callback<D = any, S = any> = (
+export type Callback<D extends Dispatch = Dispatch, S = any> = (
   ...args: any[]
 ) => (
   dispatch: D,
   getState: () => S,
   invoke: signalR.HubConnection['invoke']
 ) => void;
-export interface WithCallbacks<D = any, S = any> {
+export interface WithCallbacks<D extends Dispatch = Dispatch, S = any> {
   (): void;
   add: (name: CallbackName, callback: Callback<D, S>) => WithCallbacks<D, S>;
   callbackMap: Map<string, Callback<D, S>>;
 }
-export type WithCallbacksCreator = <D = any, S = any>() => WithCallbacks<D, S>;
+export type WithCallbacksCreator = <
+  D extends Dispatch = Dispatch,
+  S = any
+>() => WithCallbacks<D, S>;
 
-export interface MiddlewareConfig<D = any, S = any> {
+export interface MiddlewareConfig<D extends Dispatch = Dispatch, S = any> {
   callbacks: WithCallbacks<D, S>;
   connection: signalR.HubConnection;
   onStart?(): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,33 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as signalR from '@microsoft/signalr';
-
-export interface AnyAction extends Action {
-  // Allows any extra properties to be defined in an action.
-  [extraProps: string]: any;
-}
-
-export interface Action<T = any> {
-  type: T;
-}
-
-export interface Dispatch<A extends Action = AnyAction> {
-  <T extends A>(action: T): T;
-}
-
-export interface Middleware<
-  DispatchExt = {},
-  S = any,
-  D extends Dispatch = Dispatch
-> {
-  (api: MiddlewareAPI<D, S>): (
-    next: Dispatch<AnyAction>
-  ) => (action: any) => any;
-}
-
-export interface MiddlewareAPI<D extends Dispatch = Dispatch, S = any> {
-  dispatch: D;
-  getState(): S;
-}
+import { Action, Dispatch, Middleware, AnyAction } from 'redux';
 
 export interface SignalDispatch<S, A extends Action> {
   <T extends A>(action: T): T;


### PR DESCRIPTION
- Move SignalR to peerDependencies
- Add redux as peerDependency
- Add script that installs peerDependencies automatically in package development mode
- Remove duplicate redux types from `types` file
- Add type arguments to `withCallbacks`, to fix a typescript error that popped up