### PR TITLE
Update SignalR export info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ yarn add redux-signalr
 
 ## Usage
 
-**NOTE:** You don't need to install @microsoft/signalr as  it's already included in this package for convenience and exports all the code from @microsoft/signalr.
-Also, apart of SignalR invoke method, redux-signalr gives you an access to Redux state and dispatch in actions, so you don't need to use redux-thunk and redux-signalr simultaneously as the latter already does the same job.
+**NOTE:** Also, apart of SignalR invoke method, redux-signalr gives you an access to Redux state and dispatch in actions, so you don't need to use redux-thunk and redux-signalr simultaneously as the latter already does the same job.
 
 ### First, configuration
 
@@ -115,7 +114,7 @@ const callbacks = withCallbacks<Dispatch, RootState>()
 
 Create signalMiddleware with shouldConnectionStartImmediately set to false.
 
-```ts  
+```ts
 const signal = signalMiddleware({
   callbacks,
   connection,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn add redux-signalr
 
 ## Usage
 
-**NOTE:** Also, apart of SignalR invoke method, redux-signalr gives you an access to Redux state and dispatch in actions, so you don't need to use redux-thunk and redux-signalr simultaneously as the latter already does the same job.
+**NOTE:** Apart of SignalR invoke method, redux-signalr gives you an access to Redux state and dispatch in actions, so you don't need to use redux-thunk and redux-signalr simultaneously as the latter already does the same job.
 
 ### First, configuration
 


### PR DESCRIPTION
Removed info abut SignalR re-export from readme, because the package no longer does that